### PR TITLE
Add harvard-houses to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Found a cool, open dataset about Harvard that doesn't have a home? You can host 
 ## List of datasets available here
 
 - `club-lists`: a full list of all undergraduate student organizations and club sports at Harvard.
+- [harvard-houses](https://github.com/tobiasbueschel/harvard-houses): an NPM module that exposes a list of all houses at Harvard.
 
 ## Contributing
 


### PR DESCRIPTION
I'd like to add a dataset that contains names, URLs and icons of all houses at Harvard. The project is open-source and hosted on [GitHub](https://github.com/tobiasbueschel/harvard-houses). It is also available on [NPM](npmjs.com/package/harvard-houses).